### PR TITLE
Fix capitalization for discord.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Discord bot that allows you to play music in voice channels. It suppor
 Before you can run the bot, you need to have the following installed:
 
 - Python 3.x
-- Discord.py
+- discord.py
 - youtube-search-python
 - yt-dlp
 - python-dotenv


### PR DESCRIPTION
## Summary
- correct the capitalization of `discord.py` in the prerequisites list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858d837917c8329a2d9fdc3da415175